### PR TITLE
Sparse matrix times dense matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(taco-bench)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ffast-math -std=c++11")
 file(GLOB SOURCE_CODE ${PROJECT_SOURCE_DIR}/*.cpp)
-add_executable(${PROJECT_NAME} ${SOURCE_CODE})
+file(GLOB HEADERS ${PROJECT_SOURCE_DIR}/*.h)
+add_executable(${PROJECT_NAME} ${SOURCE_CODE} ${HEADERS})
 
 # To find taco
 if (NOT DEFINED ENV{TACO_INCLUDE_DIR} OR NOT DEFINED ENV{TACO_LIBRARY_DIR})

--- a/mkl-bench.h
+++ b/mkl-bench.h
@@ -199,25 +199,55 @@ using namespace std;
         double* C_mkl = (double*)malloc(sizeof(double)*rows*cols);
         double* A_mkl = (double*)exprOperands.at("A").getStorage().getValues().getData();
         double* B_mkl = (double*)exprOperands.at("B").getStorage().getValues().getData();
-        
+#ifdef MKL_PRINT_DENSE
+        for (int i=0; i<rows; i++) {
+          for (int j=0; j<cols; j++) {
+            printf(" %g ", ((double*)(exprOperands.at("A").getStorage().getValues().getData()))[i+j*rows]);
+          }
+          printf("\n");
+        }
+        printf("\n");
+        for (int i=0; i<rows; i++) {
+          for (int j=0; j<cols; j++) {
+            printf(" %g ", ((double*)(exprOperands.at("B").getStorage().getValues().getData()))[i+j*rows]);
+          }
+          printf("\n");
+        } 
+        printf("\n");
+#endif
         double alpha = 1.0;
         double beta = 0.0;
         
         // this does alpha * op(A) * op(B) + beta*C
         TACO_BENCH(
-          cblas_dgemm(CblasRowMajor, CblasTrans, CblasNoTrans, rows, cols,
+          cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, rows, cols,
                       rows, alpha, A_mkl, rows, B_mkl, cols, beta, C_mkl, rows);,
 	"\nMKL", repeat, timevalue, true);
         
         Tensor<double> C_mkl_validation({rows, cols}, Format({Dense,Dense}));
         for (int i=0; i<rows; i++) {
           for (int j=0; j<cols; j++) {
-            C_mkl_validation.insert(i,j,C_mkl[i+j*rows]);
+            C_mkl_validation.insert({i,j},C_mkl[i+j*rows]);
           }
         }
         validate("MKL", C_mkl_validation, exprOperands.at("CRef"));
-        
-        free(C_mkl);
+
+#ifdef MKL_PRINT_DENSE        
+        for (int i=0; i<rows; i++) {
+          for (int j=0; j<cols; j++) {
+            printf(" %g ", C_mkl[i+j*rows]);
+          }
+          printf("\n");
+        }
+        printf("\n");
+        for (int i=0; i<rows; i++) {
+          for (int j=0; j<cols; j++) {
+            printf(" %g ", ((double*)(exprOperands.at("CRef").getStorage().getValues().getData()))[i+j*rows]);
+          }
+          printf("\n");
+        }
+#endif
+       free(C_mkl);
         break;
       }
       default:

--- a/mkl-bench.h
+++ b/mkl-bench.h
@@ -194,11 +194,11 @@ using namespace std;
       }
       case SparsitySpMDM: {
         // use MKL to benchmark dense matrix-matrix mult
-        int rows=exprOperands.at("CRef").getDimensions(0);
-        int cols=exprOperands.at("CRef").getDimensions(1);
+        int rows=exprOperands.at("CRef").getDimension(0);
+        int cols=exprOperands.at("CRef").getDimension(1);
         double* C_mkl = (double*)malloc(sizeof(double)*rows*cols);
-        double* A_mkl = exprOperands.at("A").getStorage().getValues().getData();
-        double* B_mkl = exprOperands.at("B").getStorage().getValues().getData();
+        double* A_mkl = (double*)exprOperands.at("A").getStorage().getValues().getData();
+        double* B_mkl = (double*)exprOperands.at("B").getStorage().getValues().getData();
         
         double alpha = 1.0;
         double beta = 0.0;
@@ -206,10 +206,11 @@ using namespace std;
         // this does alpha * op(A) * op(B) + beta*C
         TACO_BENCH(
           cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, rows, cols,
-                      rows, alpha, A_mkl, rows, B_mkl, cols, beta, C_mkl, rows)
-        );
+                      rows, alpha, A_mkl, rows, B_mkl, cols, beta, C_mkl, rows);,
+	"\nMKL", repeat, timevalue, true);
         
-        validate("MKL", C_mkl, exprOperands.at("CRef"));
+        
+       // validate("MKL", C_mkl, exprOperands.at("CRef"));
         
         free(C_mkl);
         break;

--- a/mkl-bench.h
+++ b/mkl-bench.h
@@ -205,12 +205,17 @@ using namespace std;
         
         // this does alpha * op(A) * op(B) + beta*C
         TACO_BENCH(
-          cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, rows, cols,
+          cblas_dgemm(CblasRowMajor, CblasTrans, CblasNoTrans, rows, cols,
                       rows, alpha, A_mkl, rows, B_mkl, cols, beta, C_mkl, rows);,
 	"\nMKL", repeat, timevalue, true);
         
-        
-       // validate("MKL", C_mkl, exprOperands.at("CRef"));
+        Tensor<double> C_mkl_validation({rows, cols}, Format({Dense,Dense}));
+        for (int i=0; i<rows; i++) {
+          for (int j=0; j<cols; j++) {
+            C_mkl_validation.insert(i,j,C_mkl[i+j*rows]);
+          }
+        }
+        validate("MKL", C_mkl_validation, exprOperands.at("CRef"));
         
         free(C_mkl);
         break;

--- a/mkl-bench.h
+++ b/mkl-bench.h
@@ -192,6 +192,28 @@ using namespace std;
 
         break;
       }
+      case SparsitySpMDM: {
+        // use MKL to benchmark dense matrix-matrix mult
+        int rows=exprOperands.at("CRef").getDimensions(0);
+        int cols=exprOperands.at("CRef").getDimensions(1);
+        double* C_mkl = (double*)malloc(sizeof(double)*rows*cols);
+        double* A_mkl = exprOperands.at("A").getStorage().getValues().getData();
+        double* B_mkl = exprOperands.at("B").getStorage().getValues().getData();
+        
+        double alpha = 1.0;
+        double beta = 0.0;
+        
+        // this does alpha * op(A) * op(B) + beta*C
+        TACO_BENCH(
+          cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, rows, cols,
+                      rows, alpha, A_mkl, rows, B_mkl, cols, beta, C_mkl, rows)
+        );
+        
+        validate("MKL", C_mkl, exprOperands.at("CRef"));
+        
+        free(C_mkl);
+        break;
+      }
       default:
         cout << " !! Expression not implemented for MKL" << endl;
         break;

--- a/taco-bench.cpp
+++ b/taco-bench.cpp
@@ -529,10 +529,11 @@ int main(int argc, char* argv[]) {
       rows = size;
       cols = size;
       Tensor<double> B({cols, rows}, Format({Dense,Dense}));
-      util::fillTensor(B,util::FillMethod::Dense);
+      util::fillMatrix(B,util::FillMethod::Dense,1.0);
       Tensor<double> CRef({rows, cols}, Format({Dense,Dense}));
       Tensor<double> A({rows,cols}, Format({Dense,Dense}));
       util::fillMatrix(A,util::FillMethod::Dense,1.0);
+
       IndexVar i, j, k;
       CRef(i, j) = A(i, k) * B(k, j);
       CRef.compile();

--- a/taco-bench.h
+++ b/taco-bench.h
@@ -19,7 +19,7 @@ using namespace std;
 
 
 // Enum of possible expressions to Benchmark
-enum BenchExpr {SpMV, PLUS3, MATTRANSMUL, RESIDUAL, SDDMM, SparsitySpMV, SparsityTTV};
+enum BenchExpr {SpMV, PLUS3, MATTRANSMUL, RESIDUAL, SDDMM, SparsitySpMV, SparsityTTV, SparsitySpMDM};
 
 // Compare two tensors of different formats
 bool compare(const Tensor<double>&Dst, const Tensor<double>&Ref) {


### PR DESCRIPTION
Adds sparsity exploration for Sparse matrix * dense matrix, and comparison against dense MKL.  Currently, MKL `dgemm` does a slightly different operation, but it's likely we're triggering specialized MKL code so it may not make a difference.

Validation will always fail because the result comparison functions use exact comparisons (see #1).